### PR TITLE
Itk5

### DIFF
--- a/ConvertImageND.cxx
+++ b/ConvertImageND.cxx
@@ -593,17 +593,19 @@ ImageConverter<TPixel, VDim>
   else if (cmd == "-connected-components" || cmd == "-connected" || cmd == "-comp")
     {
     ConnectedComponents<TPixel, VDim> adapter(this);
-    if (argv[1][0] == '1')
-    {
-      adapter(true);
-      std::cout << "fully connected" << std::endl;
-      return 1;
-    }
-    else
-    {
-      adapter(false);
-      return 0;
-    }
+    bool fullyConnected = false;
+    int np = 0;
+    if (argc > 1 && argv[1][0] != '-')
+      {
+      switch (atoi(argv[1])) {
+      case 0: break;
+      case 1: fullyConnected = true; break;
+      default: throw ConvertException("Valid value for option -comp [0|1] (fully connected = false|true)");
+      }
+      np = 1;
+      }
+    adapter(fullyConnected);
+    return np;
     }
 
   else if (cmd == "-clear")

--- a/ConvertImageND.cxx
+++ b/ConvertImageND.cxx
@@ -593,8 +593,17 @@ ImageConverter<TPixel, VDim>
   else if (cmd == "-connected-components" || cmd == "-connected" || cmd == "-comp")
     {
     ConnectedComponents<TPixel, VDim> adapter(this);
-    adapter();
-    return 0;
+    if (argv[1][0] == '1')
+    {
+      adapter(true);
+      std::cout << "fully connected" << std::endl;
+      return 1;
+    }
+    else
+    {
+      adapter(false);
+      return 0;
+    }
     }
 
   else if (cmd == "-clear")

--- a/adapters/ConnectedComponents.cxx
+++ b/adapters/ConnectedComponents.cxx
@@ -32,7 +32,7 @@
 template <class TPixel, unsigned int VDim>
 void
 ConnectedComponents<TPixel, VDim>
-::operator() ()
+::operator() (bool fullyConnected)
 {
   // The image is assumed to be binary. If background is non-zero, call binarize
   // to map the background to zero
@@ -61,7 +61,7 @@ ConnectedComponents<TPixel, VDim>
   // Plug in the filter's components
   typename CCFilter::Pointer fltConnect = CCFilter::New();
   fltConnect->SetInput(image);
-  fltConnect->SetFullyConnected(false);
+  fltConnect->SetFullyConnected(fullyConnected);
   fltConnect->Update();
 
   // Describe what we are doing

--- a/adapters/ConnectedComponents.h
+++ b/adapters/ConnectedComponents.h
@@ -37,7 +37,7 @@ public:
 
   ConnectedComponents(Converter *c) : c(c) {}
 
-  void operator() ();
+  void operator() (bool fullyConnected);
 
 private:
   Converter *c;


### PR DESCRIPTION
This adds an optional parameter to -comp (connected components) to switch "fully connected" on and off. It is still possible to omit the parameter in order to stay compatible with the original behaviour.