### PR TITLE
Orient 4D

### DIFF
--- a/adapters/SetOrientation.cxx
+++ b/adapters/SetOrientation.cxx
@@ -30,13 +30,16 @@ void
 SetOrientation<TPixel, VDim>
 ::operator() (std::string rai)
 {
-  // Only valid for 3D images or less
-  if(VDim > 3)
-    throw ConvertException("Orientation codes only valid for up to 3D images");
+  // Only valid for 4D images or less
+  if(VDim > 4)
+    throw ConvertException("Orientation codes only valid for up to 4D images");
   
   // Check the RAI code validity (length must match image dimension)
+  // Exception for 4D images (RAI code must be 3 characters)
   if(rai.length() != VDim)
     throw ConvertException("Orientation code %s is not %d characters long", rai.c_str(), VDim);
+  else if(VDim == 4 && rai.length() != 3)
+    throw ConvertException("Orientation code %s is not 3 characters long", rai.c_str());
 
   // Get image from stack
   ImagePointer img = c->m_ImageStack.back();

--- a/adapters/SetOrientation.cxx
+++ b/adapters/SetOrientation.cxx
@@ -60,12 +60,9 @@ SetOrientation<TPixel, VDim>
     bool matched = false;
     for(size_t j = 0; j < VDim; j++)
       {
-      // 4D images default to 0 0 0 1 direction
+      // 4D Cosine Matrix is identity for 4th col/row
       if(i==3)
         {
-        // Set the last row of direction matrix to 1
-        dm.set_column(i, eye.get_row(3));
-
         // Exit loop
         matched = true;
         break;

--- a/adapters/SetOrientation.cxx
+++ b/adapters/SetOrientation.cxx
@@ -30,14 +30,14 @@ void
 SetOrientation<TPixel, VDim>
 ::operator() (std::string rai)
 {
-  // Check the RAI code validity (length must match image dimension)
-  if(rai.length() != VDim)
-    throw ConvertException("Orientation code %s is not %d characters long", rai.c_str(), VDim);
-
   // Only valid for 3D images or less
   if(VDim > 3)
     throw ConvertException("Orientation codes only valid for up to 3D images");
   
+  // Check the RAI code validity (length must match image dimension)
+  if(rai.length() != VDim)
+    throw ConvertException("Orientation code %s is not %d characters long", rai.c_str(), VDim);
+
   // Get image from stack
   ImagePointer img = c->m_ImageStack.back();
 

--- a/adapters/SetOrientation.cxx
+++ b/adapters/SetOrientation.cxx
@@ -37,9 +37,12 @@ SetOrientation<TPixel, VDim>
   // Check the RAI code validity (length must match image dimension)
   // Exception for 4D images (RAI code must be 3 characters)
   if(rai.length() != VDim)
-    throw ConvertException("Orientation code %s is not %d characters long", rai.c_str(), VDim);
-  else if(VDim == 4 && rai.length() != 3)
-    throw ConvertException("Orientation code %s is not 3 characters long", rai.c_str());
+    {
+    if(VDim == 4 && rai.length() != 3)
+      throw ConvertException("Orientation code %s is not 3 characters long", rai.c_str());
+    else if(VDim != 4)
+      throw ConvertException("Orientation code %s is not %d characters long", rai.c_str(), VDim);
+    }
 
   // Get image from stack
   ImagePointer img = c->m_ImageStack.back();
@@ -56,6 +59,16 @@ SetOrientation<TPixel, VDim>
     bool matched = false;
     for(size_t j = 0; j < VDim; j++)
       {
+      // 4D images default to 0 0 0 1 direction
+      if(i==3)
+        {
+        // Set the last row of direction matrix to 1
+        dm.set_column(i, eye.get_row(3));
+
+        // Exit loop
+        matched = true;
+        break;
+        }
       for(size_t k = 0; k < 2; k++)
         {
         if(toupper(rai[i]) == codes[j][k])

--- a/adapters/SetOrientation.cxx
+++ b/adapters/SetOrientation.cxx
@@ -38,11 +38,12 @@ SetOrientation<TPixel, VDim>
   // Exception for 4D images (RAI code must be 3 characters)
   if(rai.length() != VDim)
     {
-    if(VDim == 4 && rai.length() != 3)
-      throw ConvertException("Orientation code %s is not 3 characters long", rai.c_str());
-    else if(VDim != 4)
+    if(VDim != 4)
       throw ConvertException("Orientation code %s is not %d characters long", rai.c_str(), VDim);
     }
+  if(VDim == 4 && rai.length() != 3)
+    throw ConvertException("Orientation code %s is not 3 characters long", rai.c_str());
+
 
   // Get image from stack
   ImagePointer img = c->m_ImageStack.back();


### PR DESCRIPTION
By request of @apouch, adding functionality to c3d to orient 4D NIFTI images. 

This branch does the following:
- fixes error message order to check dimensions of input image before RAI code length
- adds 4D re-orientation functionality to c3d

Tests completed:
- incomplete/incorrect (repetitive or > 3 char) RAI code check
- `-info-full` returned expected dim[0] = 4 result with re-orientation appearing as expected
- results for 3D images remain unchanged from original functionality

Attached is `-info-full` for an original 4D image and the transformed image

[c4d_output_original.txt](https://github.com/pyushkevich/c3d/files/6817297/c4d_output_original.txt)
[c4d_output_reoriented.txt](https://github.com/pyushkevich/c3d/files/6817298/c4d_output_reoriented.txt)
