### PR TITLE
BUG: Use itkCyclicShiftImageFilter instead of shifting voxels by hand

### DIFF
--- a/adapters/WrapDimension.cxx
+++ b/adapters/WrapDimension.cxx
@@ -24,7 +24,7 @@
 =========================================================================*/
 
 #include "WrapDimension.h"
-#include "itkWrapPadImageFilter.h"
+#include "itkCyclicShiftImageFilter.h"
 #include "itkRegionOfInterestImageFilter.h"
 #include "vnl/vnl_finite.h"
 
@@ -36,52 +36,23 @@ WrapDimension<TPixel, VDim>
   // Get image from stack
   ImagePointer img = c->m_ImageStack.back();
 
-  // We will wrap the image in place. We must first calculate the offset
-  // in the flattened image that corresponds to the wrap
-  int k = 0, n = 1;
-  for(size_t i = 0; i < VDim; i++)
-    {
-    k += xWrap[i] * n;
-    n *= img->GetBufferedRegion().GetSize(i);
-    }
+  typedef itk::CyclicShiftImageFilter<ImageType> FilterType;
+  typename FilterType::Pointer filter = FilterType::New();
+  typename FilterType::OffsetType shift;
 
-  // Compute the GCD of number of voxels, offset
-  int gcd = vnl_finite_int<0>::gcd(abs(k), n);
-  int m = n / gcd;
- 
+  for(int i = 0; i < VDim; i++)
+    shift[i] = xWrap[i];
+
+  filter->SetShift(shift);
+  filter->SetInput(img);
+  filter->UpdateLargestPossibleRegion();
+
   // Explain what we are doing
   *c->verbose << "Wrapping image #" << c->m_ImageStack.size() << " by " << xWrap << endl;
-  *c->verbose << "  Rotate in memory by " << k << " bytes." << endl;
-  *c->verbose << "  GCD(" << n << "," << k << ") = " << gcd << endl;
 
-  // Get data pointer
-  TPixel *ptr = img->GetBufferPointer();
-
-  // There are gcd different starting points for the wrapping
-  for(int i = 0; i < gcd; i++)
-    {
-    TPixel q = ptr[i];
-    int p = i;
-    for(int j = 1; j < m; j++)
-      {
-      int pnext = (p + k) % n;
-      ptr[p] = ptr[pnext];
-      p = pnext;
-      if(p < 0)
-        p = p + n;
-      }
-    ptr[p] = q;
-    }
-
-  // Change the origin. Wrapping by (dx,dy,dz) means that voxel (0,0,0) is changed
-  // to the value of voxel (dx,dy,dz). So, the coordinate of (dx,dy,dz) should be
-  // the new origin.
-  itk::Point<double, VDim> org;
-  img->TransformIndexToPhysicalPoint(xWrap, org);
-  img->SetOrigin(org);
-
-  // Flag our image as modified
-  img->Modified();
+  // Save the output
+  c->m_ImageStack.pop_back();
+  c->m_ImageStack.push_back(filter->GetOutput());
 }
 
 // Invocations


### PR DESCRIPTION
Avoids problems with wrapped voxels being offset. 

Fixes #13