### PR TITLE
BUG: -resample-mm created wrong dimensions for small voxels

### DIFF
--- a/ConvertImageND.cxx
+++ b/ConvertImageND.cxx
@@ -1914,7 +1914,7 @@ ImageConverter<TPixel, VDim>
     SizeType sz = m_ImageStack.back()->GetBufferedRegion().GetSize();
     for(size_t i = 0; i < VDim; i++)
       {
-      sz[i] = static_cast<size_t>((0.5 + sz[i] * m_ImageStack.back()->GetSpacing()[i]) / vox[i]);
+      sz[i] = static_cast<size_t>(((0.5 + sz[i]) * m_ImageStack.back()->GetSpacing()[i]) / vox[i]);
       }
     ResampleImage<TPixel, VDim> adapter(this);
     adapter(sz);


### PR DESCRIPTION
It was computing an offset of 0.5 mm instead of 0.5 * (input spacing).

Before:

```
c3d -create 25x25x16 0.1x0.1x0.1mm -o 100microns.nii.gz
c3d -verbose 100microns.nii.gz -resample-mm 0.01x0.01x0.01mm -o 10microns.nii.gz
Reading #1 from 100microns.nii.gz
Resampling #1 to have[300, 300, 210] voxels.
  Interpolation method: linear
  Background intensity: 0
  Input spacing: [0.1, 0.1, 0.1]
  Input origin: [0, 0, 0]
  Output spacing: [0.00833333, 0.00833333, 0.00761905]
  Output origin: [-0.0458333, -0.0458333, -0.0461905]
Writing #1 to file 10microns.nii.gz
  Output voxel type: float[f]
  Rounding off: Disabled
```

After fix:

```
c3d -verbose 100microns.nii.gz -resample-mm 0.01x0.01x0.01mm -o 10microns.nii.gz
Resampling #1 to have[255, 255, 165] voxels.
  Interpolation method: linear
  Background intensity: 0
  Input spacing: [0.1, 0.1, 0.1]
  Input origin: [0, 0, 0]
  Output spacing: [0.00980392, 0.00980392, 0.00969697]
  Output origin: [-0.045098, -0.045098, -0.0451515]
Writing #1 to file 10microns.nii.gz
  Output voxel type: float[f]
  Rounding off: Disabled
```
