### PR TITLE
ENH: "round up" image dimensions in the output space with -resample-mm

### DIFF
--- a/ConvertImageND.cxx
+++ b/ConvertImageND.cxx
@@ -1961,7 +1961,7 @@ ImageConverter<TPixel, VDim>
     SizeType sz = m_ImageStack.back()->GetBufferedRegion().GetSize();
     for(size_t i = 0; i < VDim; i++)
       {
-      sz[i] = static_cast<size_t>(((0.5 + sz[i]) * m_ImageStack.back()->GetSpacing()[i]) / vox[i]);
+      sz[i] = static_cast<size_t>(0.5 + sz[i] * m_ImageStack.back()->GetSpacing()[i] / vox[i]);
       }
     ResampleImage<TPixel, VDim> adapter(this);
     adapter(sz);


### PR DESCRIPTION
Me again about resampling, I looked at #27 and I think it actually makes more sense than my original proposal in #16. The question is whether you "round up" by adding half a voxel in the original space, or the output space. In #27, @cajgfinger proposes the latter, which I think is probably better.

Fixes #27 