### PR TITLE
Add support to build with ITK5 (and keep support for ITK4)

### DIFF
--- a/ConvertNDLibrary.cmake
+++ b/ConvertNDLibrary.cmake
@@ -22,6 +22,15 @@ IF(WIN32)
   SOURCE_GROUP("Adapter Headers" REGULAR_EXPRESSION "adapters/*h")
 ENDIF(WIN32)
 
+IF(ITK_VERSION_MAJOR GREATER_EQUAL 5)
+  # Since ITK5, descendents of itk::InterpolateImageFunction must
+  # implement GetRadius().  However, GetRadius() does not exist in
+  # ITK4 so overriding it in the descent causes it to fail to build.
+  # When we no longer support ITK4, we can remove this.
+  ADD_DEFINITIONS(-DITK_INTERPOLATOR_HAS_GETRADIUS)
+ENDIF(ITK_VERSION_MAJOR GREATER_EQUAL 5)
+
+
 # Markdown documentation compiled into the C code
 # modified from: https://github.com/starseeker/tinyscheme-cmake/blob/master/CMakeLists.txt
 # # Rather than load the init.scm file at run time,

--- a/itkextras/itkGaussianInterpolateImageFunction.h
+++ b/itkextras/itkGaussianInterpolateImageFunction.h
@@ -89,6 +89,19 @@ public:
       }
     }
 
+#ifdef ITK_INTERPOLATOR_HAS_GETRADIUS
+  // Since ITK5 descendents of itk::InterpolateImageFunction must
+  // implement GetRadius().  Before ITK5 there was no GetRadius() to
+  // override.
+  virtual typename Superclass::SizeType GetRadius() const override
+  {
+    typename Superclass::SizeType radius;
+    for(size_t d = 0; d < VDim; d++)
+      radius.SetElement(d, (int) ceil(cut[d]));
+    return radius;
+  }
+#endif
+
   /** Set input */
   virtual void SetInputImage(const TInputImage *img)
     {

--- a/itkextras/itkHessianToObjectnessMeasureImageFilter.h
+++ b/itkextras/itkHessianToObjectnessMeasureImageFilter.h
@@ -153,7 +153,7 @@ private:
   struct AbsLessEqualCompare {
     bool operator()(EigenValueType a, EigenValueType b)
     {
-      return vnl_math_abs(a) <= vnl_math_abs(b);
+      return vnl_math::abs(a) <= vnl_math::abs(b);
     }
   };
 

--- a/itkextras/itkHessianToObjectnessMeasureImageFilter.hxx
+++ b/itkextras/itkHessianToObjectnessMeasureImageFilter.hxx
@@ -109,7 +109,7 @@ HessianToObjectnessMeasureImageFilter< TInputImage, TOutputImage >
     EigenValueArrayType sortedAbsEigenValues;
     for ( unsigned int i = 0; i < ImageDimension; i++ )
       {
-      sortedAbsEigenValues[i] = vnl_math_abs(sortedEigenValues[i]);
+      sortedAbsEigenValues[i] = vnl_math::abs(sortedEigenValues[i]);
       }
 
     // initialize the objectness measure
@@ -129,7 +129,7 @@ HessianToObjectnessMeasureImageFilter< TInputImage, TOutputImage >
         if ( vcl_fabs(m_Alpha) > 0.0 )
           {
           rA /= vcl_pow( rADenominatorBase, 1.0 / ( ImageDimension - m_ObjectDimension - 1 ) );
-          objectnessMeasure *= 1.0 - vcl_exp( -0.5 * vnl_math_sqr(rA) / vnl_math_sqr(m_Alpha) );
+          objectnessMeasure *= 1.0 - vcl_exp( -0.5 * vnl_math::sqr(rA) / vnl_math::sqr(m_Alpha) );
           }
         }
       else
@@ -150,7 +150,7 @@ HessianToObjectnessMeasureImageFilter< TInputImage, TOutputImage >
         {
         rB /= vcl_pow( rBDenominatorBase, 1.0 / ( ImageDimension - m_ObjectDimension ) );
 
-        objectnessMeasure *= vcl_exp( -0.5 * vnl_math_sqr(rB) / vnl_math_sqr(m_Beta) );
+        objectnessMeasure *= vcl_exp( -0.5 * vnl_math::sqr(rB) / vnl_math::sqr(m_Beta) );
         }
       else
         {
@@ -163,9 +163,9 @@ HessianToObjectnessMeasureImageFilter< TInputImage, TOutputImage >
       double frobeniusNormSquared = 0.0;
       for ( unsigned int i = 0; i < ImageDimension; i++ )
         {
-        frobeniusNormSquared += vnl_math_sqr(sortedAbsEigenValues[i]);
+        frobeniusNormSquared += vnl_math::sqr(sortedAbsEigenValues[i]);
         }
-      objectnessMeasure *= 1.0 - vcl_exp( -0.5 * frobeniusNormSquared / vnl_math_sqr(m_Gamma) );
+      objectnessMeasure *= 1.0 - vcl_exp( -0.5 * frobeniusNormSquared / vnl_math::sqr(m_Gamma) );
       }
 
     // in case, scale by largest absolute eigenvalue

--- a/itkextras/itkHessianToObjectnessMeasureImageFilter.hxx
+++ b/itkextras/itkHessianToObjectnessMeasureImageFilter.hxx
@@ -18,6 +18,8 @@
 #ifndef __itkHessianToObjectnessMeasureImageFilter_hxx
 #define __itkHessianToObjectnessMeasureImageFilter_hxx
 
+#include <cmath>
+
 #include "itkHessianToObjectnessMeasureImageFilter.h"
 #include "itkImageRegionIterator.h"
 #include "itkSymmetricEigenAnalysis.h"
@@ -124,12 +126,12 @@ HessianToObjectnessMeasureImageFilter< TInputImage, TOutputImage >
         {
         rADenominatorBase *= sortedAbsEigenValues[j];
         }
-      if ( vcl_fabs(rADenominatorBase) > 0.0 )
+      if ( std::fabs(rADenominatorBase) > 0.0 )
         {
-        if ( vcl_fabs(m_Alpha) > 0.0 )
+        if ( std::fabs(m_Alpha) > 0.0 )
           {
-          rA /= vcl_pow( rADenominatorBase, 1.0 / ( ImageDimension - m_ObjectDimension - 1 ) );
-          objectnessMeasure *= 1.0 - vcl_exp( -0.5 * vnl_math::sqr(rA) / vnl_math::sqr(m_Alpha) );
+          rA /= std::pow( rADenominatorBase, 1.0 / ( ImageDimension - m_ObjectDimension - 1 ) );
+          objectnessMeasure *= 1.0 - std::exp( -0.5 * vnl_math::sqr(rA) / vnl_math::sqr(m_Alpha) );
           }
         }
       else
@@ -146,11 +148,11 @@ HessianToObjectnessMeasureImageFilter< TInputImage, TOutputImage >
         {
         rBDenominatorBase *= sortedAbsEigenValues[j];
         }
-      if ( vcl_fabs(rBDenominatorBase) > 0.0 && vcl_fabs(m_Beta) > 0.0 )
+      if ( std::fabs(rBDenominatorBase) > 0.0 && std::fabs(m_Beta) > 0.0 )
         {
-        rB /= vcl_pow( rBDenominatorBase, 1.0 / ( ImageDimension - m_ObjectDimension ) );
+        rB /= std::pow( rBDenominatorBase, 1.0 / ( ImageDimension - m_ObjectDimension ) );
 
-        objectnessMeasure *= vcl_exp( -0.5 * vnl_math::sqr(rB) / vnl_math::sqr(m_Beta) );
+        objectnessMeasure *= std::exp( -0.5 * vnl_math::sqr(rB) / vnl_math::sqr(m_Beta) );
         }
       else
         {
@@ -158,14 +160,14 @@ HessianToObjectnessMeasureImageFilter< TInputImage, TOutputImage >
         }
       }
 
-    if ( vcl_fabs(m_Gamma) > 0.0 )
+    if ( std::fabs(m_Gamma) > 0.0 )
       {
       double frobeniusNormSquared = 0.0;
       for ( unsigned int i = 0; i < ImageDimension; i++ )
         {
         frobeniusNormSquared += vnl_math::sqr(sortedAbsEigenValues[i]);
         }
-      objectnessMeasure *= 1.0 - vcl_exp( -0.5 * frobeniusNormSquared / vnl_math::sqr(m_Gamma) );
+      objectnessMeasure *= 1.0 - std::exp( -0.5 * frobeniusNormSquared / vnl_math::sqr(m_Gamma) );
       }
 
     // in case, scale by largest absolute eigenvalue

--- a/itkextras/itkLabelImageGaussianInterpolateImageFunction.h
+++ b/itkextras/itkLabelImageGaussianInterpolateImageFunction.h
@@ -96,6 +96,19 @@ public:
       }
     }
 
+#ifdef ITK_INTERPOLATOR_HAS_GETRADIUS
+  // Since ITK5 descendents of itk::InterpolateImageFunction must
+  // implement GetRadius().  Before ITK5 there was no GetRadius() to
+  // override.
+  virtual typename Superclass::SizeType GetRadius() const override
+  {
+    typename Superclass::SizeType radius;
+    for(size_t d = 0; d < VDim; d++)
+      radius.SetElement(d, (int) ceil(cut[d]));
+    return radius;
+  }
+#endif
+
   /** Set input */
   virtual void SetInputImage(const TInputImage *img)
     {

--- a/itkextras/itkLabelImageGaussianInterpolateImageFunction.h
+++ b/itkextras/itkLabelImageGaussianInterpolateImageFunction.h
@@ -170,11 +170,11 @@ public:
         
         double wtest;
         OutputType V = it.Get();
-        WeightIter it = wm.find(V);
-        if(it != wm.end())
+        WeightIter w_it = wm.find(V);
+        if(w_it != wm.end())
           {
-          it->second += w;
-          wtest = it->second;
+          w_it->second += w;
+          wtest = w_it->second;
           }
         else
           {

--- a/itkextras/itkLabelOverlapMeasuresImageFilter.h
+++ b/itkextras/itkLabelOverlapMeasuresImageFilter.h
@@ -18,11 +18,11 @@
 #define __itkLabelOverlapMeasuresImageFilter_h
 
 #include <mutex>
+#include <unordered_map>
 
 #include "itkImageToImageFilter.h"
 #include "itkNumericTraits.h"
 
-#include "itk_hash_map.h"
 
 namespace itk {
 
@@ -101,7 +101,7 @@ public:
     };
 
   /** Type of the map used to store data per label */
-  typedef hash_map<LabelType, LabelSetMeasures> MapType;
+  typedef std::unordered_map<LabelType, LabelSetMeasures> MapType;
   typedef typename MapType::iterator MapIterator;
   typedef typename MapType::const_iterator MapConstIterator;
 

--- a/itkextras/itkLabelOverlapMeasuresImageFilter.h
+++ b/itkextras/itkLabelOverlapMeasuresImageFilter.h
@@ -17,8 +17,9 @@
 #ifndef __itkLabelOverlapMeasuresImageFilter_h
 #define __itkLabelOverlapMeasuresImageFilter_h
 
+#include <mutex>
+
 #include "itkImageToImageFilter.h"
-#include "itkFastMutexLock.h"
 #include "itkNumericTraits.h"
 
 #include "itk_hash_map.h"
@@ -195,7 +196,7 @@ private:
   std::vector<MapType>                            m_LabelSetMeasuresPerThread;
   MapType                                         m_LabelSetMeasures;
 
-  SimpleFastMutexLock                             m_Mutex;
+  std::mutex                                      m_Mutex;
 
 }; // end of class
 

--- a/itkextras/itkMultiScaleHessianBasedMeasureImageFilter.hxx
+++ b/itkextras/itkMultiScaleHessianBasedMeasureImageFilter.hxx
@@ -18,6 +18,8 @@
 #ifndef __itkMultiScaleHessianBasedMeasureImageFilter_hxx
 #define __itkMultiScaleHessianBasedMeasureImageFilter_hxx
 
+#include <cmath>
+
 #include "itkMultiScaleHessianBasedMeasureImageFilter.h"
 #include "itkImageRegionIterator.h"
 #include "vnl/vnl_math.h"
@@ -349,8 +351,8 @@ MultiScaleHessianBasedMeasureImageFilter
     case Self::LogarithmicSigmaSteps:
       {
       const double stepSize =
-        vnl_math::max( 1e-10, ( vcl_log(m_SigmaMaximum) - vcl_log(m_SigmaMinimum) ) / ( m_NumberOfSigmaSteps - 1 ) );
-      sigmaValue = vcl_exp(vcl_log (m_SigmaMinimum) + stepSize * scaleLevel);
+        vnl_math::max( 1e-10, ( std::log(m_SigmaMaximum) - std::log(m_SigmaMinimum) ) / ( m_NumberOfSigmaSteps - 1 ) );
+      sigmaValue = std::exp(std::log (m_SigmaMinimum) + stepSize * scaleLevel);
       break;
       }
     default:

--- a/itkextras/itkMultiScaleHessianBasedMeasureImageFilter.hxx
+++ b/itkextras/itkMultiScaleHessianBasedMeasureImageFilter.hxx
@@ -342,14 +342,14 @@ MultiScaleHessianBasedMeasureImageFilter
     {
     case Self::EquispacedSigmaSteps:
       {
-      const double stepSize = vnl_math_max( 1e-10, ( m_SigmaMaximum - m_SigmaMinimum ) / ( m_NumberOfSigmaSteps - 1 ) );
+      const double stepSize = vnl_math::max( 1e-10, ( m_SigmaMaximum - m_SigmaMinimum ) / ( m_NumberOfSigmaSteps - 1 ) );
       sigmaValue = m_SigmaMinimum + stepSize * scaleLevel;
       break;
       }
     case Self::LogarithmicSigmaSteps:
       {
       const double stepSize =
-        vnl_math_max( 1e-10, ( vcl_log(m_SigmaMaximum) - vcl_log(m_SigmaMinimum) ) / ( m_NumberOfSigmaSteps - 1 ) );
+        vnl_math::max( 1e-10, ( vcl_log(m_SigmaMaximum) - vcl_log(m_SigmaMinimum) ) / ( m_NumberOfSigmaSteps - 1 ) );
       sigmaValue = vcl_exp(vcl_log (m_SigmaMinimum) + stepSize * scaleLevel);
       break;
       }


### PR DESCRIPTION
Convert3D does not currently build with ITK5. There are a series of very minor changes required. This pull request implements them (and keeps support to build with ITK4).