### PR TITLE
Fixed compiling error for gcc/gxx version 9.4.0 (included with Ubuntu 20.04) and older

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ ENDIF(CONVERT3D_USE_ITK_REMOTE_MODULES)
 IF(NOT CONVERT3D_BUILD_AS_SUBPROJECT)
 
   # Do we want to build the UI
-  OPTION(BUILD_GUI "Do you want to build the Qt-based C3D user interfaace?" OFF)
+  OPTION(BUILD_GUI "Do you want to build the Qt-based C3D user interface?" OFF)
 
   # List of ITK modules
   SET(ITK_MODULE_LIST

--- a/itkextras/ImageCollectionConstIteratorWithIndex.h
+++ b/itkextras/ImageCollectionConstIteratorWithIndex.h
@@ -294,8 +294,8 @@ protected:
     std::vector<int> dest_offset;
   };
 
-  typedef typename Self::ImageData<TScalarImage> ScalarImageData;
-  typedef typename Self::ImageData<TVectorImage> VectorImageData;
+  typedef Self::ImageData<TScalarImage> ScalarImageData;
+  typedef Self::ImageData<TVectorImage> VectorImageData;
 
   std::vector<ScalarImageData> m_ScalarImageData;
   std::vector<VectorImageData> m_VectorImageData;

--- a/itkextras/itkSLICSuperVoxelImageFilter.hxx
+++ b/itkextras/itkSLICSuperVoxelImageFilter.hxx
@@ -111,7 +111,7 @@ SLICSuperVoxelImageFilter<TInputImage, TLabelImage, TRealImage>
     imgCluster->TransformContinuousIndexToPhysicalPoint(cidx, ptx);
     input->TransformPhysicalPointToIndex(ptx, idxInput);
 
-    // Seach the gradient magnitude image for the
+    // Search the gradient magnitude image for the
     itGrad.SetLocation(idxInput);
 
     bool inbounds;


### PR DESCRIPTION
The error that occurs:
```
In file included from /builddir/deps/c3d/adapters/RFTrain.cxx:27:0:
/builddir/deps/c3d/itkextras/ImageCollectionConstIteratorWithIndex.h:297:48: error: 'typename ImageCollectionConstIteratorWithIndex<TScalarImage, TVectorImage>::Self::ImageData' names 'template<class TScalarImage, class TVectorImage> template<class T> class ImageCollectionConstIteratorWithIndex<TScalarImage, TVectorImage>::ImageData', which is not a type
   typedef typename Self::ImageData<TScalarImage> ScalarImageData;
                                                ^
/builddir/deps/c3d/itkextras/ImageCollectionConstIteratorWithIndex.h:298:48: error: 'typename ImageCollectionConstIteratorWithIndex<TScalarImage, TVectorImage>::Self::ImageData' names 'template<class TScalarImage, class TVectorImage> template<class T> class ImageCollectionConstIteratorWithIndex<TScalarImage, TVectorImage>::ImageData', which is not a type
   typedef typename Self::ImageData<TVectorImage> VectorImageData;
                                                ^
In file included from /builddir/deps/c3d/itkextras/RandomForest/RandomForestClassifyImageFilter.txx:7:0,
                 from /builddir/deps/c3d/itkextras/RandomForest/RandomForestClassifyImageFilter.h:100,
                 from /builddir/deps/c3d/adapters/RFApply.cxx:27:
/builddir/deps/c3d/itkextras/ImageCollectionConstIteratorWithIndex.h:297:48: error: 'typename ImageCollectionConstIteratorWithIndex<TScalarImage, TVectorImage>::Self::ImageData' names 'template<class TScalarImage, class TVectorImage> template<class T> class ImageCollectionConstIteratorWithIndex<TScalarImage, TVectorImage>::ImageData', which is not a type
   typedef typename Self::ImageData<TScalarImage> ScalarImageData;
                                                ^
/builddir/deps/c3d/itkextras/ImageCollectionConstIteratorWithIndex.h:298:48: error: 'typename ImageCollectionConstIteratorWithIndex<TScalarImage, TVectorImage>::Self::ImageData' names 'template<class TScalarImage, class TVectorImage> template<class T> class ImageCollectionConstIteratorWithIndex<TScalarImage, TVectorImage>::ImageData', which is not a type
   typedef typename Self::ImageData<TVectorImage> VectorImageData;
                                                ^
make[2]: *** [CMakeFiles/cnd_driver.dir/adapters/RFTrain.cxx.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: *** [CMakeFiles/cnd_driver.dir/adapters/RFApply.cxx.o] Error 1
make[1]: *** [CMakeFiles/cnd_driver.dir/all] Error 2
make: *** [all] Error 2
```

the problem has been tested to be present for the following build environments:
* ubuntu 14.04 with gcc/gxx 4.8.4 using itk 4.7.2 (where removing typename fixes the problem)
* ubuntu 16.04 with gcc/gxx 5.4.0 using itk 5.2.1 (where removing typename fixes the problem)
* ubuntu 18.04 with gcc/gxx 7.5.0 using itk 5.2.1 (where removing typename fixes the problem)
* ubuntu 20.04 with gcc/gxx 9.4.0 using itk 5.2.1 (where removing typename fixes the problem)

problem does not exist on:
* ubuntu 22.04 with gcc/gxx 11.4.0 using itk 5.2.1 (and also works if typename is removed)

the fix is to remove 'typename' from 'typedef typename' as it does not seem to be needed.