### PR TITLE
 extend -slice and -slice-all commands to support more than on position entry using comma separated input

### DIFF
--- a/adapters/ExtractSlice.cxx
+++ b/adapters/ExtractSlice.cxx
@@ -109,11 +109,11 @@ ExtractSlice<TPixel, VDim>
 {
   // Check input availability
   if(c->m_ImageStack.size() < n_comp)
-    throw ConvertException("At least %d images are required on the stack for the -slice command", n_comp);
+    throw ConvertException("At least %d images are required on the stack for the -slice or -slice-all command", n_comp);
 
   // Check that the images are the same size
   if(n_comp > 1 && !c->CheckStackSameDimensions(n_comp))
-    throw ConvertException("All images must be the same size for the -mslice command");
+    throw ConvertException("All images must be the same size for the -slice-all command");
 
   // Get the last image for the size command considerations
   SizeType size = c->PeekImage(0)->GetBufferedRegion().GetSize();
@@ -129,7 +129,7 @@ ExtractSlice<TPixel, VDim>
   else if (!axis.compare("w") || !axis.compare("3") || !axis.compare("t"))
     slicedir = 3;
   else
-    throw ConvertException("first parameter to -slice must be x,y,z or w");
+    throw ConvertException("first parameter to -slice or -slice-all must be one of either 0,1,2,3 or x,y,z,w/t");
 
   // Now determine the pattern of the second parameter. Allowed formats are
   // 1. 15      // slice 15 (0-based indexing)
@@ -196,12 +196,12 @@ ExtractSlice<TPixel, VDim>
   // Make sure all is legit
   if(pos_first < pos_last && pos_step <= 0)
     throw ConvertException(
-      "Wrong slice list specification %d:%d:%d for -slice command! Step should be positive.",
+      "Wrong slice list specification %d:%d:%d for -slice or -slice-all command! Step should be positive.",
       pos_first, pos_step, pos_last);
 
   if(pos_first > pos_last && pos_step >= 0)
     throw ConvertException(
-      "Wrong slice list specification %d:%d:%d for -slice command! Step should be negative.",
+      "Wrong slice list specification %d:%d:%d for -slice or -slice-all command! Step should be negative.",
       pos_first, pos_step, pos_last);
 
   // Take the last n_comp images on the stack

--- a/doc/c3d.md
+++ b/doc/c3d.md
@@ -1379,15 +1379,15 @@ Applies the Laplacian sharpening filter from ITK, which accentuates the edges in
 
 Syntax: `-slice axis position_spec`
 
-Extracts a slice along the specified axis (x,y or z). The position specifier **position_spec** can be a single slice or a range of slices. For a single slice, it can be specified as a number or a percentage. Numbering is zero-based, i.e, the first slice is slice 0, the last slice is N-1, where N is the number of slices. For a range, use MATLAB notation first:step:last. The slice is placed on the stack as an image with size 1 in the last dimension. You can save the slice as a 2D PNG image. 
+Extracts a slice along the specified axis (x,y or z). The position specifier **position_spec** can be a single slice or a range of slices. For a single slice, it can be specified as a number or a percentage. Numbering is zero-based, i.e, the first slice is slice 0, the last slice is N-1, where N is the number of slices. For a range, use MATLAB notation first:step:last. The slice is placed on the stack as an image with size 1 in the last dimension. You can save the slice as a 2D PNG image.
 
     c3d input.img -slice x 128 -o myslice.nii.gz
     c3d input.img -slice y 50% myslice.nii.gz
     c3d input.img -slice z 25% -type uchar -stretch 0 2000 0 255 -o myslice.png
-    c3d input.img -slice z 0:-1 -oo slice%0d.nii.gz 
-    c3d input.img -slice z 20%:10%:80% -oo slice%0d.nii.gz 
+    c3d input.img -slice z 0:-1 -oo slice%0d.nii.gz
+    c3d input.img -slice z 20%:10%:80% -oo slice%0d.nii.gz
 
-With the new command **c4d**, the **-slice** command can be used to extract volumes from a 4D image. This can be useful to reformat a 4D NIFTI image as a 3D multi-component NIFTI image, using the command 
+With the new command **c4d**, the **-slice** command can be used to extract volumes from a 4D image. This can be useful to reformat a 4D NIFTI image as a 3D multi-component NIFTI image, using the command.
 
     c4d input4d.nii.gz -slice w 0:-1 -omc output3d_multicomp.nii.gz
 

--- a/doc/c3d.md
+++ b/doc/c3d.md
@@ -1387,6 +1387,10 @@ Extracts a slice along the specified axis (x,y or z). The position specifier **p
     c3d input.img -slice z 0:-1 -oo slice%0d.nii.gz
     c3d input.img -slice z 20%:10%:80% -oo slice%0d.nii.gz
 
+Additional more than one entry or range can be given at the same time using the comma separated list notation.
+
+    c3d input.img -slice z 20%,30%:10%:70%,80% -oo slice%0d.nii.gz
+
 With the new command **c4d**, the **-slice** command can be used to extract volumes from a 4D image. This can be useful to reformat a 4D NIFTI image as a 3D multi-component NIFTI image, using the command.
 
     c4d input4d.nii.gz -slice w 0:-1 -omc output3d_multicomp.nii.gz


### PR DESCRIPTION
example of new supported input:
    c3d input.img -slice z 20%,30%:10%:70%,80% -oo slice%0d.nii.gz
