### PR TITLE
regression: fails to compile with itk versions newer than 4.12.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ IF(NOT CONVERT3D_BUILD_AS_SUBPROJECT)
     ITKTransform
     ITKTransformFactory
     ITKImageIO
+    ITKNIFTI
     ITKTransformIO)
 
   # Add the remote modules


### PR DESCRIPTION
Currently c3d fails to compile against ITK version 4.12.2 and newer (have tested versions 5.1.0, 5.1.2 and 5.2.1) and gives the following compiler error:

```bash
[ 12%] Building CXX object CMakeFiles/cnd_driver.dir/adapters/PrintImageInfo.cxx.o
adapters/PrintImageInfo.cxx:30:23: fatal error: nifti1_io.h: No such file or directory
 #include <nifti1_io.h>

compilation terminated.
make[2]: *** [CMakeFiles/cnd_driver.dir/adapters/PrintImageInfo.cxx.o] Error 1
make[1]: *** [CMakeFiles/cnd_driver.dir/all] Error 2
make: *** [all] Error 2
```

I found that the the problem is caused by the changes I made in the patch https://github.com/pyushkevich/c3d/commit/80458056935d6f136bab549502963f71c7202559

Further investigation reviled root cause of why this is happening is the change https://github.com/InsightSoftwareConsortium/ITK/commit/940f68ec18b15e500cc22d8ddb1dbae34b66cb2f where ITKNIFTI was moved from DEPENDS to PRIVATE_DEPENDS. Which was introduced https://github.com/InsightSoftwareConsortium/ITK/compare/v4.12.1...v4.12.2

This means that for convert3d to compile against ITK version 4.12.2 and newer, ITKNIFTI must be explicit added as dependency in the cmake file (as ITKNIFTI is now actively being used inside adapters/PrintImageInfo.cxx).

Note: Besides ITK versions 5.1.0, 5.1.2, and 5.2.1, I have also tested compiling against ITK version 4.7.2 (which is earlier that 4.12.2), all these versions compiles with the change and are confirmed to be working.