### PR TITLE
fixed warnings and configure errors using newer cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,13 @@
-PROJECT(CONVERT3D)
-
 # CMake compatibility code
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12)
 if(COMMAND cmake_policy)
   CMAKE_POLICY(SET CMP0003 NEW)
   CMAKE_POLICY(SET CMP0077 NEW)
   CMAKE_POLICY(SET CMP0042 NEW)
+  CMAKE_POLICY(SET CMP0057 NEW)
 endif(COMMAND cmake_policy)
+
+PROJECT(CONVERT3D)
 
 #--------------------------------------------------------------------------------
 # VERSION


### PR DESCRIPTION
Specifically the warnings and errors are:

```
CMake Warning (dev) at /project/picsl/jhao/tk/installed/itk/lib64/cmake/ITK-5.4/ITKConfig.cmake:95 (if):
  Policy CMP0057 is not set: Support new IN_LIST if() operator.  Run "cmake
  --help-policy CMP0057" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

  IN_LIST will be interpreted as an operator when the policy is set to NEW.
  Since the policy is not set the OLD behavior will be used.
Call Stack (most recent call first):
  CMakeLists.txt:92 (FIND_PACKAGE)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

```
CMake Warning (dev) at CMakeLists.txt:1 (PROJECT):
  cmake_minimum_required() should be called prior to this top-level project()
  call.  Please see the cmake-commands(7) manual for usage documentation of
  both commands.
This warning is for project developers.  Use -Wno-dev to suppress it.`

`CMake Error at /project/picsl/jhao/tk/installed/itk/lib64/cmake/ITK-5.4/ITKConfig.cmake:95 (if):
  if given arguments:

    "ITK_FIND_REQUIRED_ITKAnisotropicSmoothing" "OR" "M" "IN_LIST" "ITK_MODULES_ENABLED"

  Unknown arguments specified
Call Stack (most recent call first):
  CMakeLists.txt:92 (FIND_PACKAGE)

```