### PR TITLE
fixed an infinite recursive call resulting seg fault

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ CTestConfig.cmake.user*
 
 # Sphinx
 doc/_*
+
+
+# build directory
+build/

--- a/api/ConvertAPI.cxx
+++ b/api/ConvertAPI.cxx
@@ -266,7 +266,7 @@ ConvertAPI<TPixel,VDim>
   vsnprintf(buffer, 8192, cmdline, args);
   va_end (args);
 
-  this->Execute(buffer);
+  this->ExecuteNoFormatting(buffer);
 }
 
 template class ConvertAPI<double, 2>;


### PR DESCRIPTION
Addressing https://github.com/pyushkevich/itksnap/issues/156

Also added `build` folder to the gitignore file. In some scenario build folder has to be inside the project directory for the intellisense to work.