### PR TITLE
COMP: Migrate deprecated itkTypeMacro/itkNewMacro for ITK 6 (release-5.4 compatible)

### DIFF
--- a/adapters/ExtrudeSegmentation.cxx
+++ b/adapters/ExtrudeSegmentation.cxx
@@ -39,7 +39,7 @@ public:
   typedef itk::SmartPointer<Self> Pointer;
   typedef itk::SmartPointer<const Self> ConstPointer;
 
-  itkOverrideGetNameOfClassMacro(LineFunctorImageFilter)
+  itkOverrideGetNameOfClassMacro(LineFunctorImageFilter);
 
   itkNewMacro(Self);
   /** Some typedefs. */

--- a/adapters/ExtrudeSegmentation.cxx
+++ b/adapters/ExtrudeSegmentation.cxx
@@ -41,8 +41,7 @@ public:
 
   itkOverrideGetNameOfClassMacro(LineFunctorImageFilter)
 
-  itkNewMacro(Self)
-
+  itkNewMacro(Self);
   /** Some typedefs. */
   typedef TFunction                                        FunctorType;
 

--- a/adapters/ExtrudeSegmentation.cxx
+++ b/adapters/ExtrudeSegmentation.cxx
@@ -39,7 +39,7 @@ public:
   typedef itk::SmartPointer<Self> Pointer;
   typedef itk::SmartPointer<const Self> ConstPointer;
 
-  itkTypeMacro(LineFunctorImageFilter, itk::InPlaceImageFilter)
+  itkOverrideGetNameOfClassMacro(LineFunctorImageFilter)
 
   itkNewMacro(Self)
 

--- a/adapters/FillBackgroundWithNeighborhoodNoise.cxx
+++ b/adapters/FillBackgroundWithNeighborhoodNoise.cxx
@@ -52,8 +52,7 @@ public:
 
   itkOverrideGetNameOfClassMacro(StatisticsToGaussianNoiseImageFilter)
 
-  itkNewMacro(Self) 
-
+  itkNewMacro(Self);
   void SetStatisticsImage(StatisticsImageType *image) 
     { itk::ProcessObject::SetInput("statistics", image); }
 

--- a/adapters/FillBackgroundWithNeighborhoodNoise.cxx
+++ b/adapters/FillBackgroundWithNeighborhoodNoise.cxx
@@ -50,7 +50,7 @@ public:
   typedef typename OutputImageType::RegionType OutputImageRegionType;
   typedef typename OutputImageType::PixelType OutputPixelType;
 
-  itkTypeMacro(StatisticsToGaussianNoiseImageFilter, itk::ImageToImageFilter)
+  itkOverrideGetNameOfClassMacro(StatisticsToGaussianNoiseImageFilter)
 
   itkNewMacro(Self) 
 

--- a/adapters/FillBackgroundWithNeighborhoodNoise.cxx
+++ b/adapters/FillBackgroundWithNeighborhoodNoise.cxx
@@ -50,7 +50,7 @@ public:
   typedef typename OutputImageType::RegionType OutputImageRegionType;
   typedef typename OutputImageType::PixelType OutputPixelType;
 
-  itkOverrideGetNameOfClassMacro(StatisticsToGaussianNoiseImageFilter)
+  itkOverrideGetNameOfClassMacro(StatisticsToGaussianNoiseImageFilter);
 
   itkNewMacro(Self);
   void SetStatisticsImage(StatisticsImageType *image) 

--- a/adapters/GeneralLinearModel.cxx
+++ b/adapters/GeneralLinearModel.cxx
@@ -24,9 +24,45 @@
 =========================================================================*/
 
 #include "GeneralLinearModel.h"
-#include "vnl/vnl_file_matrix.h"
+#include "vnl/vnl_matrix.h"
 #include "vnl/vnl_rank.h"
 #include "vnl/algo/vnl_matrix_inverse.h"
+#include <fstream>
+#include <sstream>
+#include <vector>
+
+namespace {
+// Read a whitespace-delimited ASCII matrix, one row per line.
+bool ReadAsciiMatrix(const char *fn, vnl_matrix<double> &out)
+{
+  std::ifstream in(fn);
+  if(!in)
+    return false;
+  std::vector<std::vector<double>> rows;
+  std::string line;
+  while(std::getline(in, line))
+  {
+    std::istringstream iss(line);
+    std::vector<double> row;
+    double v;
+    while(iss >> v)
+      row.push_back(v);
+    if(!row.empty())
+      rows.push_back(row);
+  }
+  if(rows.empty())
+    return false;
+  const size_t nc = rows.front().size();
+  for(const auto &r : rows)
+    if(r.size() != nc)
+      return false;
+  out.set_size(rows.size(), nc);
+  for(size_t i = 0; i < rows.size(); ++i)
+    for(size_t j = 0; j < nc; ++j)
+      out(i, j) = rows[i][j];
+  return true;
+}
+} // namespace
 
 template <class TPixel, unsigned int VDim>
 void
@@ -34,13 +70,13 @@ GeneralLinearModel<TPixel, VDim>
 ::operator() (string fn_matrix, string fn_contrast)
 {
   // Read the matrix from file
-  vnl_file_matrix<double> mat(fn_matrix.c_str());
-  if(!mat)
+  vnl_matrix<double> mat;
+  if(!ReadAsciiMatrix(fn_matrix.c_str(), mat))
     throw string("Unable to read matrix from file given");
 
   // Read the contrast from file
-  vnl_file_matrix<double> con(fn_contrast.c_str());
-  if(!con)
+  vnl_matrix<double> con;
+  if(!ReadAsciiMatrix(fn_contrast.c_str(), con))
     throw string("Unable to read contrast from file given");
 
   // Check that the number of images matches

--- a/adapters/LevelSetSegmentation.cxx
+++ b/adapters/LevelSetSegmentation.cxx
@@ -93,7 +93,7 @@ public:
   typedef typename InputImageType::PixelType InputPixelType;
 
   // Standard ITK Macros
-  itkTypeMacro(MyLevelSetFilter, itk::SegmentationLevelSetFilter);
+  itkOverrideGetNameOfClassMacro(MyLevelSetFilter);
   itkNewMacro(Self);
 
 protected:

--- a/adapters/VoxelwiseRegression.cxx
+++ b/adapters/VoxelwiseRegression.cxx
@@ -24,7 +24,6 @@
 =========================================================================*/
 
 #include "VoxelwiseRegression.h"
-#include "vnl/vnl_file_matrix.h"
 #include "vnl/vnl_rank.h"
 #include "vnl/algo/vnl_matrix_inverse.h"
 

--- a/adapters/WrapDimension.cxx
+++ b/adapters/WrapDimension.cxx
@@ -26,7 +26,6 @@
 #include "WrapDimension.h"
 #include "itkCyclicShiftImageFilter.h"
 #include "itkRegionOfInterestImageFilter.h"
-#include "vnl/vnl_finite.h"
 
 template <class TPixel, unsigned int VDim>
 void

--- a/itkextras/ImageCollectionConstIteratorWithIndex.h
+++ b/itkextras/ImageCollectionConstIteratorWithIndex.h
@@ -207,10 +207,10 @@ public:
     }
 
   /** Get the number of components across the collection */
-  itkGetMacro(TotalComponents, unsigned int)
+  itkGetMacro(TotalComponents, unsigned int);
 
   /** Get the optional neighborhood size */
-  itkGetMacro(NeighborhoodSize, int)
+  itkGetMacro(NeighborhoodSize, int);
 
   /** Standard iterator operations */
   bool IsAtEnd() const

--- a/itkextras/ImageCollectionConstIteratorWithIndex.h
+++ b/itkextras/ImageCollectionConstIteratorWithIndex.h
@@ -136,7 +136,7 @@ public:
   itkStaticConstMacro(ImageDimension, unsigned int, TScalarImage::ImageDimension);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacroNoParent(ImageCollectionConstIteratorWithIndex);
+  itkVirtualGetNameOfClassMacro(ImageCollectionConstIteratorWithIndex);
 
   /** Index typedef support. */
   typedef typename TScalarImage::IndexType         IndexType;

--- a/itkextras/OneDimensionalInPlaceAccumulateFilter.h
+++ b/itkextras/OneDimensionalInPlaceAccumulateFilter.h
@@ -47,8 +47,7 @@ public:
 
   itkOverrideGetNameOfClassMacro(OneDimensionalInPlaceAccumulateFilter)
 
-  itkNewMacro(Self)
-
+  itkNewMacro(Self);
   /** Some convenient typedefs. */
   typedef TInputImage                                  InputImageType;
   typedef TInputImage                                  OutputImageType;

--- a/itkextras/OneDimensionalInPlaceAccumulateFilter.h
+++ b/itkextras/OneDimensionalInPlaceAccumulateFilter.h
@@ -45,7 +45,7 @@ public:
   typedef itk::SmartPointer<Self> Pointer;
   typedef itk::SmartPointer<const Self> ConstPointer;
 
-  itkTypeMacro(OneDimensionalInPlaceAccumulateFilter, itk::InPlaceImageFilter)
+  itkOverrideGetNameOfClassMacro(OneDimensionalInPlaceAccumulateFilter)
 
   itkNewMacro(Self)
 

--- a/itkextras/OneDimensionalInPlaceAccumulateFilter.h
+++ b/itkextras/OneDimensionalInPlaceAccumulateFilter.h
@@ -45,7 +45,7 @@ public:
   typedef itk::SmartPointer<Self> Pointer;
   typedef itk::SmartPointer<const Self> ConstPointer;
 
-  itkOverrideGetNameOfClassMacro(OneDimensionalInPlaceAccumulateFilter)
+  itkOverrideGetNameOfClassMacro(OneDimensionalInPlaceAccumulateFilter);
 
   itkNewMacro(Self);
   /** Some convenient typedefs. */
@@ -62,11 +62,11 @@ public:
   /** ImageDimension constant */
   itkStaticConstMacro(OutputImageDimension, unsigned int, TInputImage::ImageDimension);
 
-  itkGetMacro(Radius, int)
-  itkSetMacro(Radius, int)
+  itkGetMacro(Radius, int);
+  itkSetMacro(Radius, int);
 
-  itkGetMacro(Dimension, int)
-  itkSetMacro(Dimension, int)
+  itkGetMacro(Dimension, int);
+  itkSetMacro(Dimension, int);
 
   /**
    * Set the range of components in the input image that will be processed by the
@@ -77,8 +77,8 @@ public:
    */
   void SetComponentRange(int num_ignored_at_start, int num_ignored_at_end);
 
-  itkGetMacro(ComponentOffsetFront, int)
-  itkGetMacro(ComponentOffsetBack, int)
+  itkGetMacro(ComponentOffsetFront, int);
+  itkGetMacro(ComponentOffsetBack, int);
 
 protected:
 

--- a/itkextras/PovRayIO/itkPovRayDF3ImageIO.h
+++ b/itkextras/PovRayIO/itkPovRayDF3ImageIO.h
@@ -50,7 +50,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(PovRayDF3ImageIO, Superclass);
+  itkOverrideGetNameOfClassMacro(PovRayDF3ImageIO);
 
   /*-------- This part of the interfaces deals with reading data. ----- */
 

--- a/itkextras/PovRayIO/itkPovRayDF3ImageIOFactory.h
+++ b/itkextras/PovRayIO/itkPovRayDF3ImageIOFactory.h
@@ -42,7 +42,7 @@ public:
   itkFactorylessNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(PovRayDF3ImageIOFactory, ObjectFactoryBase);
+  itkOverrideGetNameOfClassMacro(PovRayDF3ImageIOFactory);
 
   /** Register one factory of this type  */
   static void RegisterOneFactory(void)

--- a/itkextras/RandomForest/RandomForestClassifier.h
+++ b/itkextras/RandomForest/RandomForestClassifier.h
@@ -54,28 +54,28 @@ public:
     }
 
   // Get the random forest
-  itkGetMacro(Forest, RandomForestType *)
+  itkGetMacro(Forest, RandomForestType *);
 
   // Get the patch radius
-  itkGetMacro(PatchRadius, const SizeType &)
-  itkSetMacro(PatchRadius, SizeType)
+  itkGetMacro(PatchRadius, const SizeType &);
+  itkSetMacro(PatchRadius, SizeType);
 
   /** Whether coordinates of the voxels are used as features */
-  itkGetMacro(UseCoordinateFeatures, bool)
-  itkSetMacro(UseCoordinateFeatures, bool)
+  itkGetMacro(UseCoordinateFeatures, bool);
+  itkSetMacro(UseCoordinateFeatures, bool);
 
   // Set the bias parameter (adjusts the mapping of FG probability to speed)
-  itkGetMacro(BiasParameter, double)
-  itkSetMacro(BiasParameter, double)
+  itkGetMacro(BiasParameter, double);
+  itkSetMacro(BiasParameter, double);
 
   // Get a reference to the valid label state
-  itkGetMacro(ValidLabel, bool &)
+  itkGetMacro(ValidLabel, bool &);
 
   // Get a reference to the class index to label mapping
-  itkGetMacro(ClassToLabelMapping, MappingType &)
+  itkGetMacro(ClassToLabelMapping, MappingType &);
 
   // Get a reference to the class weights array
-  itkGetMacro(ClassWeights, WeightArray &)
+  itkGetMacro(ClassWeights, WeightArray &);
 
   // Set the weight for a class
   void SetClassWeight(size_t class_id, double weight)

--- a/itkextras/RandomForest/RandomForestClassifier.h
+++ b/itkextras/RandomForest/RandomForestClassifier.h
@@ -26,8 +26,7 @@ public:
   typedef itk::SmartPointer<Self> Pointer;
   typedef itk::SmartPointer<const Self> ConstPointer;
 
-  itkNewMacro(Self)
-  
+  itkNewMacro(Self);  
   // typedefs
   typedef TPixel GreyType;
   typedef TLabel LabelType;

--- a/itkextras/RandomForest/RandomForestClassifyImageFilter.h
+++ b/itkextras/RandomForest/RandomForestClassifyImageFilter.h
@@ -40,8 +40,7 @@ public:
   typedef itk::SmartPointer<const Self>                    ConstPointer;
 
   /** Method for creation through the object factory. */
-  itkNewMacro(Self)
-
+  itkNewMacro(Self);
   /** Image dimension. */
   itkStaticConstMacro(ImageDimension, unsigned int,
                       TInputImage::ImageDimension);

--- a/itkextras/RandomForest/RandomForestClassifyImageFilter.h
+++ b/itkextras/RandomForest/RandomForestClassifyImageFilter.h
@@ -66,7 +66,7 @@ public:
    */
   void SetGenerateClassProbabilities(bool flag);
 
-  itkGetMacro(GenerateClassProbabilities, bool)
+  itkGetMacro(GenerateClassProbabilities, bool);
 
   /** Get the current classifier */
   itkGetMacro(Classifier, ClassifierType *);

--- a/itkextras/Texture/itkCoocurrenceTextureFeaturesImageFilter.h
+++ b/itkextras/Texture/itkCoocurrenceTextureFeaturesImageFilter.h
@@ -95,7 +95,7 @@ public:
   using ConstPointer = SmartPointer< const Self >;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(CoocurrenceTextureFeaturesImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(CoocurrenceTextureFeaturesImageFilter);
 
   /** standard New() method support */
   itkNewMacro(Self);

--- a/itkextras/Texture/itkFirstOrderTextureFeaturesImageFilter.h
+++ b/itkextras/Texture/itkFirstOrderTextureFeaturesImageFilter.h
@@ -70,8 +70,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(FirstOrderTextureFeaturesImageFilter,
-               MovingHistogramMorphologyImageFilter);
+  itkOverrideGetNameOfClassMacro(FirstOrderTextureFeaturesImageFilter);
 
   /** Image related type alias. */
   using InputImageType = TInputImage;

--- a/itkextras/Texture/itkRunLengthTextureFeaturesImageFilter.h
+++ b/itkextras/Texture/itkRunLengthTextureFeaturesImageFilter.h
@@ -108,7 +108,7 @@ public:
   using ConstPointer = SmartPointer< const Self >;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(RunLengthTextureFeaturesImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(RunLengthTextureFeaturesImageFilter);
 
   /** standard New() method support */
   itkNewMacro(Self);

--- a/itkextras/UnaryFunctorVectorImageFilter.h
+++ b/itkextras/UnaryFunctorVectorImageFilter.h
@@ -47,7 +47,7 @@ public:
   typedef itk::SmartPointer<Self> Pointer;
   typedef itk::SmartPointer<const Self> ConstPointer;
 
-  itkTypeMacro(UnaryFunctorVectorImageFilter, itk::InPlaceImageFilter)
+  itkOverrideGetNameOfClassMacro(UnaryFunctorVectorImageFilter)
 
   itkNewMacro(Self)
 

--- a/itkextras/UnaryFunctorVectorImageFilter.h
+++ b/itkextras/UnaryFunctorVectorImageFilter.h
@@ -47,7 +47,7 @@ public:
   typedef itk::SmartPointer<Self> Pointer;
   typedef itk::SmartPointer<const Self> ConstPointer;
 
-  itkOverrideGetNameOfClassMacro(UnaryFunctorVectorImageFilter)
+  itkOverrideGetNameOfClassMacro(UnaryFunctorVectorImageFilter);
 
   itkNewMacro(Self);
   /** Some typedefs. */

--- a/itkextras/UnaryFunctorVectorImageFilter.h
+++ b/itkextras/UnaryFunctorVectorImageFilter.h
@@ -49,8 +49,7 @@ public:
 
   itkOverrideGetNameOfClassMacro(UnaryFunctorVectorImageFilter)
 
-  itkNewMacro(Self)
-
+  itkNewMacro(Self);
   /** Some typedefs. */
   typedef TFunction FunctorType;
 

--- a/itkextras/VoxBoIO/itkVoxBoCUBImageIO.h
+++ b/itkextras/VoxBoIO/itkVoxBoCUBImageIO.h
@@ -51,7 +51,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(VoxBoCUBImageIO, Superclass);
+  itkOverrideGetNameOfClassMacro(VoxBoCUBImageIO);
 
   /*-------- This part of the interfaces deals with reading data. ----- */
 

--- a/itkextras/VoxBoIO/itkVoxBoCUBImageIOFactory.h
+++ b/itkextras/VoxBoIO/itkVoxBoCUBImageIOFactory.h
@@ -42,7 +42,7 @@ public:
   itkFactorylessNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(VoxBoCUBImageIOFactory, ObjectFactoryBase);
+  itkOverrideGetNameOfClassMacro(VoxBoCUBImageIOFactory);
 
   /** Register one factory of this type  */
   static void RegisterOneFactory(void)

--- a/itkextras/gsGSAffine3DTransform.h
+++ b/itkextras/gsGSAffine3DTransform.h
@@ -32,7 +32,7 @@ public:
 
   /** Run-time type information (and related methods).   */
   // itkTypeMacro( GSAffine3DTransform, Rigid3DTransform );
-  itkTypeMacro( GSAffine3DTransform, MatrixOffsetTransformBase );
+  itkOverrideGetNameOfClassMacro(GSAffine3DTransform);
 
   /** Dimension of parameters   */
   itkStaticConstMacro(InputSpaceDimension, unsigned int, 3);

--- a/itkextras/itkGaussianInterpolateImageFunction.h
+++ b/itkextras/itkGaussianInterpolateImageFunction.h
@@ -47,7 +47,7 @@ public:
   typedef SmartPointer<const Self>  ConstPointer;
   
   /** Run-time type information (and related methods). */
-  itkTypeMacro(GaussianInterpolateImageFunction, InterpolateImageFunction);
+  itkOverrideGetNameOfClassMacro(GaussianInterpolateImageFunction);
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);  

--- a/itkextras/itkHessianToObjectnessMeasureImageFilter.h
+++ b/itkextras/itkHessianToObjectnessMeasureImageFilter.h
@@ -87,7 +87,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(HessianToObjectnessMeasureImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(HessianToObjectnessMeasureImageFilter);
 
   /** Set/Get Alpha, the weight corresponding to R_A
    * (the ratio of the smallest eigenvalue that has to be large to the larger ones).

--- a/itkextras/itkLabelContourImageFilter.h
+++ b/itkextras/itkLabelContourImageFilter.h
@@ -110,7 +110,7 @@ public:
   /**
    * Run-time type information (and related methods)
    */
-  itkTypeMacro(LabelContourImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(LabelContourImageFilter);
   
   /**
    * Method for creation through the object factory.

--- a/itkextras/itkLabelImageGaussianInterpolateImageFunction.h
+++ b/itkextras/itkLabelImageGaussianInterpolateImageFunction.h
@@ -54,7 +54,7 @@ public:
   typedef SmartPointer<const Self>  ConstPointer;
   
   /** Run-time type information (and related methods). */
-  itkTypeMacro(LabelImageGaussianInterpolateImageFunction, InterpolateImageFunction);
+  itkOverrideGetNameOfClassMacro(LabelImageGaussianInterpolateImageFunction);
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);  

--- a/itkextras/itkLabelOverlapMeasuresImageFilter.h
+++ b/itkextras/itkLabelOverlapMeasuresImageFilter.h
@@ -48,7 +48,7 @@ public:
   itkNewMacro( Self );
 
   /** Runtime information support. */
-  itkTypeMacro( LabelOverlapMeasuresImageFilter, ImageToImageFilter );
+  itkOverrideGetNameOfClassMacro(LabelOverlapMeasuresImageFilter);
 
   /** Image related typedefs. */
   typedef TLabelImage                                   LabelImageType;

--- a/itkextras/itkMultiScaleHessianBasedMeasureImageFilter.h
+++ b/itkextras/itkMultiScaleHessianBasedMeasureImageFilter.h
@@ -108,8 +108,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(MultiScaleHessianBasedMeasureImageFilter,
-               ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(MultiScaleHessianBasedMeasureImageFilter);
 
   /** Set/Get macros for SigmaMin */
   itkSetMacro(SigmaMinimum, double);

--- a/itkextras/itkOrientedRASImage.h
+++ b/itkextras/itkOrientedRASImage.h
@@ -24,7 +24,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(OrientedRASImage, Image);
+  itkOverrideGetNameOfClassMacro(OrientedRASImage);
 
   /** Index typedef support. An index is used to access pixel values. */
   typedef typename Superclass::IndexType  IndexType;

--- a/itkextras/itkSLICSuperVoxelImageFilter.h
+++ b/itkextras/itkSLICSuperVoxelImageFilter.h
@@ -33,7 +33,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(SLICSuperVoxelImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(SLICSuperVoxelImageFilter);
 
   /** Set a scalar-valued gradient magnitude image, used to push initial cluster
    *  centers away from the edges */

--- a/itkextras/itkTopologyPreservingDigitalSurfaceEvolutionImageFilter.h
+++ b/itkextras/itkTopologyPreservingDigitalSurfaceEvolutionImageFilter.h
@@ -33,8 +33,7 @@ public:
   typedef SmartPointer<const Self>                                ConstPointer;
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro( TopologyPreservingDigitalSurfaceEvolutionImageFilter, 
-    InPlaceImageFilter );
+  itkOverrideGetNameOfClassMacro(TopologyPreservingDigitalSurfaceEvolutionImageFilter);
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );


### PR DESCRIPTION
Make c3d build against ITK 6 — including builds configured with `ITK_FUTURE_LEGACY_REMOVE` and with the VXL 2026-06-09 VNL — while remaining compatible with the ITK release-5.4 series.

Verified: full c3d source compiles and links against both **ITK 6** (all executables produced) and **ITK v5.4.6** (zero errors).

<details>
<summary>Root cause</summary>

Three independent ITK 6 breakages:

1. Under `ITK_FUTURE_LEGACY_REMOVE`, `itkTypeMacro`/`itkTypeMacroNoParent` become `static_assert(false, …)` directing callers to `itkOverrideGetNameOfClassMacro`/`itkVirtualGetNameOfClassMacro`.
2. ITK 6 defines `ITK_NOOP_STATEMENT` as `static_assert(true, "")` unconditionally, and every itk macro ends in it — so bare `itkGetMacro`/`itkSetMacro`/`itkNewMacro`/`itkOverrideGetNameOfClassMacro` invocations (no trailing `;`) fail with `expected ';' after 'static_assert'`. (ITK 5.4 left this expansion empty, so the same code built there.)
3. The VXL 2026-06-09 sync removed `vnl/vnl_file_matrix.h` and `vnl/vnl_finite.h`.

</details>

<details>
<summary>Changes (six commits)</summary>

1. `itkTypeMacro(X, Super)` → `itkOverrideGetNameOfClassMacro(X)`
2. `itkTypeMacroNoParent(X)` → `itkVirtualGetNameOfClassMacro(X)`
3. Trailing `;` on `itkNewMacro` invocations
4. Replace `vnl_file_matrix<double>` with a small ASCII matrix reader (`GeneralLinearModel`); drop a stale include in `VoxelwiseRegression`
5. Trailing `;` on `itkGetMacro`/`itkSetMacro`/`itkOverrideGetNameOfClassMacro` invocations
6. Drop stale `vnl/vnl_finite.h` include in `WrapDimension`

Replacement macros exist since ITK 5.4.0; added semicolons are empty declarations under 5.4; the ASCII reader depends only on `vnl_matrix` + `<fstream>`. All six changes build against both series.

</details>

<details>
<summary>Verification</summary>

- **ITK 6** (with `MorphologicalContourInterpolation` remote module): full source compiles (91/91), links `c3d`, `c2d`, `c4d`, `c3d_affine_tool`; `c3d -version` runs.
- **ITK v5.4.6**: `configure rc=0`, `build rc=0`, zero errors.

</details>

<!--
provenance: claude-code session 2026-07-05
base: v1.4.6 (origin/master 16ea136)
verified: ITK6 (svdc forest) full build+link of all executables; ITK v5.4.6 (itkv5 forest) zero errors
note: forest link needed -L$CONDA_PREFIX/lib for -lfftw3_threads (harness env, not a c3d source issue)
-->
